### PR TITLE
Fixes links to Arrow docs

### DIFF
--- a/content/_posts/2017-08-01-arrow-docs.md
+++ b/content/_posts/2017-08-01-arrow-docs.md
@@ -6,4 +6,4 @@ category: articles
 tags: [core, optics, fx, incubator, meta]
 link: https://arrow-kt.io/
 ---
-Take a look at the Λrrow documentation [`Here`]({{ '/docs/arrow/core/try' | relative_url }}). Test and modify real-time code snippets.
+Take a look at the Λrrow documentation [`Here`]({{ 'https://arrow-kt.io/docs/core/' | relative_url }}). Test and modify real-time code snippets.

--- a/content/_posts/2017-09-17-handling-exceptions-arrow.md
+++ b/content/_posts/2017-09-17-handling-exceptions-arrow.md
@@ -6,6 +6,6 @@ category: articles
 tags: [core]
 link: https://www.spantree.net/blog/2017/09/15/kotlin-exception-handling-with-kategory.html
 ---
-[@uris77](https://github.com/uris77) explains how to use [`Try`]({{ '/docs/arrow/core/try' | relative_url }}) in real world examples.
+[@uris77](https://github.com/uris77) explains how to use [`Try`]({{ 'https://arrow-kt.io/docs/apidocs/arrow-core-data/arrow.core/-try/#' | relative_url }}) in real world examples.
 
 [Handling Kotlin Exceptions with Arrow – A Functional Approach](https://www.spantree.net/blog/2017/09/15/kotlin-exception-handling-with-kategory.html)

--- a/content/_posts/2017-11-22-happy-path.md
+++ b/content/_posts/2017-11-22-happy-path.md
@@ -6,6 +6,6 @@ category: articles
 tag: [core]
 link: https://medium.com/@javipacheco/happy-path-kotlin-actors-arrow-proof-of-concept-322e9099d2ea
 ---
-[@javipacheco](https://github.com/javipacheco) creates a Proof of Concept architecture for Android using the Actor pattern and modelling the domain with [`Either`]({{ '/docs/arrow/core/either' | relative_url }}).
+[@javipacheco](https://github.com/javipacheco) creates a Proof of Concept architecture for Android using the Actor pattern and modelling the domain with [`Either`]({{ 'https://arrow-kt.io/docs/apidocs/arrow-core-data/arrow.core/-either/' | relative_url }}).
 
 [Happy Path: Kotlin + Actors + Arrow](https://medium.com/@javipacheco/happy-path-kotlin-actors-arrow-proof-of-concept-322e9099d2ea)


### PR DESCRIPTION
This Pr fixes some links that are pointing to the Arrow documentation that had changed since now they don´t belong to the same repo.