### PR TITLE
Fix categories and icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,41 +2,59 @@
 
 A showcase of tutorials, conference presentations, and other Arrow-related content.
 
-## Adding a Post
+## Adding a resource
 
 ```
+---
 title: Handling exceptions in Arrow
 icon: /img/icon-article.svg
 header-image: /img/blog-image-header.png
 category: articles
 tags: [core]
 link: https://www.spantree.net/blog/2017/09/15/kotlin-exception-handling-with-kategory.html
+---
+Description of the resource.
 ```
 The fields to fill are described below:
 
 ### title
-The title of the post
+The title of the resource
 ### header-image
-The image the post will show.
+The image the resource will show.
 Set to `/img/blog-image-header.png` if you don´t have an image.
 ### category
-Specify the category of the post
+Specify the category of the resource
 ##### Tutorials
+```
 category: tutorials
+```
 ##### Conferences
+```
 category: conferences
+```
 ##### Videos
+```
 category: videos
+```
 ##### Articles
+```
 category: articles
+```
 ##### SlideDecks
+
+If a talk wasn't recorded, you can add the slide deck with this category:
+
+```
 category: slidedecks
+```
+
+If the talk was recorded, please, choose `category: conferences` and add the link of the corresponding slide deck in the description.
 ### tags
-Here you can specify the Arrow module or modules to which the post is related: `core`, `fx`, `optics`, `incubator`, or `meta`
+Here you can specify the Arrow module or modules to which the resource is related: `core`, `fx`, `optics`, `incubator`, or `meta`
 You can add more than one tag as follows:
 `tags: [core, fx]`
 ### link
-The link to the post
+The link to the resource
 ### event
 In case of a conference, please, indicate the event. For instance: `event: Lambda World, Cádiz, Spain`
 

--- a/README.md
+++ b/README.md
@@ -16,17 +16,6 @@ The fields to fill are described below:
 
 ### title
 The title of the post
-### icon
-There are 4 different icons to choose from
-##### Article
-`icon: /img/icon-article.svg`
-##### Podcast
-`icon: /img/icon-podcast.svg`
-##### Talk
-`icon: /img/icon-talk.svg`
-##### Video
-`icon: /img/icon-video.svg`
-
 ### header-image
 The image the post will show.
 Set to `/img/blog-image-header.png` if you don´t have an image.
@@ -40,12 +29,16 @@ category: conferences
 category: videos
 ##### Articles
 category: articles
+##### SlideDecks
+category: slidedecks
 ### tags
 Here you can specify the Arrow module or modules to which the post is related: `core`, `fx`, `optics`, `incubator`, or `meta`
 You can add more than one tag as follows:
 `tags: [core, fx]`
 ### link
 The link to the post
+### event
+In case of a conference, please, indicate the event. For instance: `event: Lambda World, Cádiz, Spain`
 
 
 ## Books section

--- a/README.md
+++ b/README.md
@@ -4,10 +4,17 @@ A showcase of tutorials, conference presentations, and other Arrow-related conte
 
 ## Adding a resource
 
+The file needs to be placed in the `content/_posts/` folder and the date will be indicated in the filename:
+
+```
+yyyy-mm-dd-<name>.md
+```
+
+An example of file content:
+
 ```
 ---
 title: Handling exceptions in Arrow
-icon: /img/icon-article.svg
 header-image: /img/blog-image-header.png
 category: articles
 tags: [core]

--- a/content/_data/menu-media-categories.yml
+++ b/content/_data/menu-media-categories.yml
@@ -18,3 +18,7 @@ tab:
     - title: Articles
       category: articles
       url: /articles
+
+    - title: SlideDecks
+      category: slidedecks
+      url: /slidedecks

--- a/content/_includes/_article-card-icon.html
+++ b/content/_includes/_article-card-icon.html
@@ -1,0 +1,14 @@
+{% if post.category == 'videos' %}
+{% assign icon-image = '/img/icon-video.svg' %}
+{% elsif post.category == 'conferences' %}
+{% assign icon-image = '/img/icon-video.svg' %}
+{% elsif post.category == 'articles' %}
+{% assign icon-image = '/img/icon-article.svg' %}
+{% elsif post.category == 'tutorials' %}
+{% assign icon-image = '/img/icon-article.svg' %}
+{% elsif post.category == 'slidedecks' %}
+{% assign icon-image = '/img/icon-article.svg' %}
+{% endif %}
+<div class="icon">
+  <img src="{{ icon-image }}" alt="">
+</div>

--- a/content/_includes/_article-card.html
+++ b/content/_includes/_article-card.html
@@ -5,11 +5,7 @@
 {% assign meta = '#CD151D' %}
 <article class="article-card">
   <div class="article-card-header">
-    {% if post.icon %}
-    <div class="icon">
-      <img src="{{ post.icon }}" alt="post icon">
-    </div>
-    {% endif %}
+    {% include _article-card-icon.html %}
 
     {% if post.link %}
     <a href="{{ post.link }}" target="_blank" rel="noopener noreferrer" class="header-container">

--- a/content/_layouts/media_slidedecks.html
+++ b/content/_layouts/media_slidedecks.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+{% include _head.html %}
+
+<body>
+  {% include _nav.html %}
+  {% include _tab.html %}
+  {% include _icon-filter.html %}
+  {% include _article-list.html blogCategory = "slidedecks"%}
+  {% include _books-list.html%}
+  {% include _footer.html %}
+</body>
+
+</html>

--- a/content/_posts/2017-08-01-arrow-docs.md
+++ b/content/_posts/2017-08-01-arrow-docs.md
@@ -1,6 +1,5 @@
 ---
 title: Arrow Docs
-icon: /img/icon-article.svg
 header-image: /img/twitter-card.png
 category: articles
 tags: [core, optics, fx, incubator, meta]

--- a/content/_posts/2017-09-17-handling-exceptions-arrow.md
+++ b/content/_posts/2017-09-17-handling-exceptions-arrow.md
@@ -1,6 +1,5 @@
 ---
 title: Handling exceptions in Arrow
-icon: /img/icon-article.svg
 header-image: /img/blog-image-header.png
 category: articles
 tags: [core]

--- a/content/_posts/2017-10-20-functional-approach.md
+++ b/content/_posts/2017-10-20-functional-approach.md
@@ -1,8 +1,7 @@
 ---
 title: Functional approach to Android architecture using Kotlin
-icon: /img/icon-talk.svg
 header-image: https://img.youtube.com/vi/qGef3sFAIxU/maxresdefault.jpg
-category: videos
+category: conferences
 tags: [core]
 link: https://www.youtube.com/watch?v=qGef3sFAIxU
 event: Mobilization 7, Łódź

--- a/content/_posts/2017-11-02-fp-kotlin.md
+++ b/content/_posts/2017-11-02-fp-kotlin.md
@@ -1,6 +1,5 @@
 ---
 title: Functional Programming in Kotlin
-icon: /img/icon-podcast.svg
 header-image: https://cdn-images-1.medium.com/max/600/1*NpQ5mqoY4SH5iwsWG35RqQ.jpeg
 category: tutorials
 tags: [core, fx, mtl]

--- a/content/_posts/2017-11-09-pragmatic-functionalist.md
+++ b/content/_posts/2017-11-09-pragmatic-functionalist.md
@@ -1,8 +1,7 @@
 ---
 title: Kotlin for the Pragmatic Functionalist
-icon: /img/icon-talk.svg
 header-image: https://img.youtube.com/vi/s9oMED6ZikQ/maxresdefault.jpg
-category: videos
+category: conferences
 tags: [core]
 link: https://www.youtube.com/watch?v=s9oMED6ZikQ
 event: KotlinConf, San Francisco

--- a/content/_posts/2017-11-17-architectures.md
+++ b/content/_posts/2017-11-17-architectures.md
@@ -1,8 +1,7 @@
 ---
 title: Architectures Using Functional Programming Concepts
-icon: /img/icon-talk.svg
 header-image: https://img.youtube.com/vi/qI1ctQ0293o/maxresdefault.jpg
-category: videos
+category: conferences
 tags: [core]
 link: https://www.youtube.com/watch?v=qI1ctQ0293o
 event: KotlinConf, San Francisco

--- a/content/_posts/2017-11-22-happy-path.md
+++ b/content/_posts/2017-11-22-happy-path.md
@@ -1,6 +1,5 @@
 ---
 title: "Happy path: Kotlin + Actors + Arrow"
-icon: /img/icon-article.svg
 header-image: https://cdn-images-1.medium.com/max/600/1*kF_bpeNe0THMssFEa2enYA.jpeg
 category: articles
 tag: [core]

--- a/content/_posts/2017-11-24-building-dsl-kotlin.md
+++ b/content/_posts/2017-11-24-building-dsl-kotlin.md
@@ -1,8 +1,7 @@
 ---
 title: Building a DSL… in Kotlin
-icon: /img/icon-talk.svg
 header-image: https://img.youtube.com/vi/qGef3sFAIxU/maxresdefault.jpg
-category: videos
+category: conferences
 tags: [core]
 link: https://www.youtube.com/watch?v=qGef3sFAIxU
 event: droidconSF, San Francisco

--- a/content/_posts/2017-11-29-fp-kotlin-arrow.md
+++ b/content/_posts/2017-11-29-fp-kotlin-arrow.md
@@ -1,8 +1,7 @@
 ---
 title: Functional Programming in Kotlin with Arrow
-icon: /img/icon-talk.svg
 header-image: https://img.youtube.com/vi/IL5XzaCMKpQ/maxresdefault.jpg
-category: videos
+category: conferences
 tags: [core]
 link: https://www.youtube.com/watch?v=IL5XzaCMKpQ
 event: Lambda World, Cádiz

--- a/content/_posts/2018-01-17-optics-type-classes-arrow.md
+++ b/content/_posts/2018-01-17-optics-type-classes-arrow.md
@@ -1,8 +1,7 @@
 ---
 title: Optics and Type Classes in Arrow
-icon: /img/icon-podcast.svg
 header-image: https://speakerd.s3.amazonaws.com/presentations/4b938d99415a416c8f908ac5302a66cb/slide_0.jpg
-category: articles
+category: slidedecks
 tags: [core, optics]
 event: Kotlin Brooklyn Meetup
 link: https://speakerdeck.com/heyitsmohit/functional-programming-with-arrow

--- a/content/_posts/2018-03-21-morphisms.md
+++ b/content/_posts/2018-03-21-morphisms.md
@@ -1,8 +1,7 @@
 ---
 title: It's all about morphisms
-icon: /img/icon-talk.svg
 header-image: https://img.youtube.com/vi/Eq8dv4H3RTE/maxresdefault.jpg
-category: videos
+category: conferences
 tags: [core]
 link: https://www.youtube.com/watch?v=Eq8dv4H3RTE
 event: Voxxed Days, Vienna

--- a/content/_posts/2018-03-26-kotlin-arrow.md
+++ b/content/_posts/2018-03-26-kotlin-arrow.md
@@ -1,8 +1,7 @@
 ---
 title: Introduction to Kotlin Arrow by Jacob Bass
-icon: /img/icon-talk.svg
 header-image: https://img.youtube.com/vi/tM2wEI-e80E/maxresdefault.jpg
-category: videos
+category: conferences
 tags: [core]
 link: https://www.youtube.com/watch?v=tM2wEI-e80E
 event: Kotlin Meetup, Sydney

--- a/content/_posts/2018-04-14-android-functional-validation.md
+++ b/content/_posts/2018-04-14-android-functional-validation.md
@@ -1,6 +1,5 @@
 ---
 title: Android Functional Validation
-icon: /img/icon-video.svg
 header-image: https://i.vimeocdn.com/video/713283357_1280x720.jpg
 category: tutorials
 tags: [core]

--- a/content/_posts/2018-04-23-how-do-i.md
+++ b/content/_posts/2018-04-23-how-do-i.md
@@ -1,6 +1,5 @@
 ---
 title: "1/n - How do I… in FP: Validation"
-icon: /img/icon-article.svg
 header-image: https://images.unsplash.com/photo-1518169811655-27c3a4327016?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=600&fit=max&ixid=eyJhcHBfaWQiOjExNzczfQ&s=383b467064497d356a0b05b3a3d180be
 category: tutorials
 tags: [core]

--- a/content/_posts/2018-06-22-hk-types.md
+++ b/content/_posts/2018-06-22-hk-types.md
@@ -1,8 +1,7 @@
 ---
 title: Higher Kinded Types in a Lower Kinded Language by Jacob Bass
-icon: /img/icon-talk.svg
 header-image: https://img.youtube.com/vi/ERM0mBPNLHc/maxresdefault.jpg
-category: videos
+category: conferences
 tags: [core]
 link: https://www.youtube.com/watch?v=ERM0mBPNLHc
 event: Yow! Lambda Jam, Sydney, Australia

--- a/content/_posts/2018-06-24-arrow-101.md
+++ b/content/_posts/2018-06-24-arrow-101.md
@@ -1,6 +1,5 @@
 ---
 title: Arrow 101  -  Building an Android app using Functional Programming
-icon: /img/icon-podcast.svg
 header-image: https://cdn-images-1.medium.com/max/2000/1*7HJJpOQE8M1-xXW0_5eePQ.png
 category: articles
 tags: [core]

--- a/content/_posts/2018-06-24-state-ecosystem.md
+++ b/content/_posts/2018-06-24-state-ecosystem.md
@@ -1,8 +1,7 @@
 ---
 title: "State of the functional ecosystem in Kotlin: Mid 2018 checkup"
-icon: /img/icon-podcast.svg
 header-image: https://img.youtube.com/vi/q_1xPYQLyaU/maxresdefault.jpg
-category: videos
+category: conferences
 tags: [core, optics, fx, incubator]
 link: https://www.youtube.com/watch?v=q_1xPYQLyaU
 event: Conference for Kotliners, Budapest

--- a/content/_posts/2018-06-27-fp-kotlin-arrow.md
+++ b/content/_posts/2018-06-27-fp-kotlin-arrow.md
@@ -1,8 +1,7 @@
 ---
 title: Functional Programming in Kotlin with Arrow by Emmanuel Nhan
-icon: /img/icon-podcast.svg
 header-image: https://image.slidesharecdn.com/fpkotlinsunnytech-180628144002/95/functional-programming-in-kotlin-with-arrow-sunnytech-2018-1-638.jpg
-category: articles
+category: slidedecks
 tags: [core]
 link: https://www.slideshare.net/EmmanuelNhan/functional-programming-in-kotlin-with-arrow-sunnytech-2018
 event: Sunny Tech, Montpellier

--- a/content/_posts/2018-07-24-arrow-fp-kotlin.md
+++ b/content/_posts/2018-07-24-arrow-fp-kotlin.md
@@ -1,8 +1,7 @@
 ---
 title: Arrow and Functional Programming for Kotlin Developers
-icon: /img/icon-video.svg
 header-image: https://img.youtube.com/vi/qYgilPqMOp0/maxresdefault.jpg
-category: videos
+category: conferences
 tags: [core]
 link: https://www.youtube.com/watch?v=qYgilPqMOp0
 event: DroidJam India, Bangalore, India

--- a/content/_posts/2018-10-05-kotlin-conf-fp-in-kotlin-with-arrow.md
+++ b/content/_posts/2018-10-05-kotlin-conf-fp-in-kotlin-with-arrow.md
@@ -1,8 +1,7 @@
 ---
 title: Architecting Typed FP Applications & Libraries in Kotlin with Λrrow
-icon: /img/icon-talk.svg
 header-image: https://img.youtube.com/vi/VOZZTSuDMFE/maxresdefault.jpg
-category: videos
+category: conferences
 tags: [core, fx]
 link: https://www.youtube.com/watch?v=VOZZTSuDMFE
 event: KotlinConf, Amsterdam

--- a/content/_posts/2018-10-21-polyjokes.md
+++ b/content/_posts/2018-10-21-polyjokes.md
@@ -1,6 +1,5 @@
 ---
 title: Polyjokes  -  A polymorphic approach using Arrow
-icon: /img/icon-article.svg
 header-image: /img/blog-image-header.png
 category: articles
 tags: [core]

--- a/content/_posts/2018-11-07-simple-management-dependency.md
+++ b/content/_posts/2018-11-07-simple-management-dependency.md
@@ -1,8 +1,7 @@
 ---
 title: Simple Dependency Management in Kotlin
-icon: /img/icon-talk.svg
 header-image: https://img.youtube.com/vi/CR5h2Wq1yPE/maxresdefault.jpg
-category: videos
+category: conferences
 tags: [core]
 link: https://www.youtube.com/watch?v=CR5h2Wq1yPE
 event: AndroidTO, Toronto

--- a/content/_posts/2018-11-15-flashcards.md
+++ b/content/_posts/2018-11-15-flashcards.md
@@ -1,6 +1,5 @@
 ---
 title: Arrow Tiny Cards Flashcards
-icon: /img/icon-article.svg
 header-image: https://d17u0960v8a9bp.cloudfront.net/press/tinycards-iOS-icon.jpg
 category: articles
 tags: [core, optics, fx, incubator]

--- a/content/_posts/2018-11-24-ank.md
+++ b/content/_posts/2018-11-24-ank.md
@@ -1,8 +1,7 @@
 ---
 title: Manual documentation is dead. Long live automated documentation! Automated documentation with ΛNK
-icon: /img/icon-video.svg
 header-image: https://img.youtube.com/vi/kr8iWE4Jfhc/maxresdefault.jpg
-category: videos
+category: conferences
 tags: [core, incubator]
 link: https://www.youtube.com/watch?v=kr8iWE4Jfhc
 event: droidconSF, San Francisco

--- a/content/_posts/2018-11-30-hangman.md
+++ b/content/_posts/2018-11-30-hangman.md
@@ -1,8 +1,7 @@
 ---
 title: Functional Hangman Game written with Arrow
-icon: /img/icon-article.svg
 header-image: /img/blog-image-header.png
-category: conferences
+category: articles
 tags: [core, fx]
 link: https://lordraydenmk.github.io/2018/functional-hangman-in-kotlin-with-arrow/
 ---

--- a/content/_posts/2019-01-03-getting-started.md
+++ b/content/_posts/2019-01-03-getting-started.md
@@ -1,6 +1,5 @@
 ---
 title: "Getting started with FP in Kotlin and Arrow: Typeclasses"
-icon: /img/icon-article.svg
 header-image: /img/blog-image-header.png
 category: articles
 tags: [core, fx]

--- a/content/_posts/2019-02-03-arrow-webflux.md
+++ b/content/_posts/2019-02-03-arrow-webflux.md
@@ -1,6 +1,5 @@
 ---
 title: "Webflux with Kotlin and Arrow"
-icon: /img/icon-article.svg
 header-image: /img/blog-image-header.png
 category: articles
 tags: [core, fx]

--- a/content/_posts/2019-02-10-imperative-functional-programming-arrow.md
+++ b/content/_posts/2019-02-10-imperative-functional-programming-arrow.md
@@ -1,6 +1,5 @@
 ---
 title: From Imperative to Functional Programming using Arrow
-icon: /img/icon-article.svg
 header-image: https://blog.frankel.ch/assets/resources/imperative-functional-programming/arrow-brand.svg
 category: tutorials
 tags: [core, fx]

--- a/content/_posts/2019-03-12-immutable-conv-1.md
+++ b/content/_posts/2019-03-12-immutable-conv-1.md
@@ -1,6 +1,5 @@
 ---
 title: Immutable Conversations - Past and Future of Arrow
-icon: /img/icon-video.svg
 header-image: https://img.youtube.com/vi/YtchNDjQuTU/maxresdefault.jpg
 category: videos
 tags: [core, fx]

--- a/content/_posts/2019-06-04-keep-87-and-typeclasses.md
+++ b/content/_posts/2019-06-04-keep-87-and-typeclasses.md
@@ -1,6 +1,5 @@
 ---
 title: How KEEP-87 & Typeclasses will change the way we write Kotlin
-icon: /img/icon-article.svg
 header-image: https://quickbirdstudios.com/blog/wp-content/uploads/2019/05/xFirebird.jpg.pagespeed.ic.e0DeqxTqSE.webp
 category: articles
 tags: [core]

--- a/content/_posts/2019-06-07-kotliners-arrow-fx.md
+++ b/content/_posts/2019-06-07-kotliners-arrow-fx.md
@@ -1,9 +1,9 @@
 ---
-title: Kotliners 2019 - ArrowFx Functional Programming for the masses
-icon: /img/icon-video.svg
+title: "ArrowFx: Functional Programming for the masses"
 header-image: https://img.youtube.com/vi/uyqqoooKpmI/maxresdefault.jpg
-category: videos
+category: conferences
 tag: [fx]
 link: https://www.youtube.com/watch?v=uyqqoooKpmI
+event: Kotliners, Budapest
 ---
 In this talk we recap about the imminent future of Functional Programming in Kotlin. With ArrowFx you are able to encode “effectful” programs in a controlled way following the FP principles through a direct syntax. You’ll think you’re writing imperative code!

--- a/content/_posts/2019-07-02-modular-app-kotlin.md
+++ b/content/_posts/2019-07-02-modular-app-kotlin.md
@@ -1,6 +1,5 @@
 ---
 title: Modular functional programming with Kotlin
-icon: /img/icon-article.svg
 header-image: https://blog.frankel.ch/assets/resources/imperative-functional-programming/arrow-brand.svg
 category: articles
 tag: [core]

--- a/content/_posts/2019-07-05-testing-with-modules.md
+++ b/content/_posts/2019-07-05-testing-with-modules.md
@@ -1,6 +1,5 @@
 ---
 title: Self-contained example of testing with modules and Arrow FX
-icon: /img/icon-article.svg
 header-image: https://blog.frankel.ch/assets/resources/imperative-functional-programming/arrow-brand.svg
 category: articles
 tags: [core, fx]

--- a/content/_posts/2019-07-22-polymorphic-fx.md
+++ b/content/_posts/2019-07-22-polymorphic-fx.md
@@ -1,6 +1,5 @@
 ---
 title: Effect polymorphism with Arrow FX
-icon: /img/icon-article.svg
 header-image: https://blog.frankel.ch/assets/resources/imperative-functional-programming/arrow-brand.svg
 category: articles
 tags: [fx]

--- a/content/_posts/2019-10-18-lambda-world-arrow-meta.md
+++ b/content/_posts/2019-10-18-lambda-world-arrow-meta.md
@@ -1,9 +1,9 @@
 ---
 title: Arrow Meta - Enabling Functional Programming in the Kotlin Compiler
-icon: /img/icon-video.svg
 header-image: https://img.youtube.com/vi/WKR384ZeBgk/maxresdefault.jpg
-category: videos
+category: conferences
 tags: [meta]
 link: https://www.youtube.com/watch?v=WKR384ZeBgk
+event: Lambda World, Cádiz, Spain
 ---
 Arrow Meta is a library that empowers library and application authors with the ability to write plugins for the Kotlin compiler. Compiler plugins have access to all compiler phases and can intercept and modify the AST, descriptors, and IR intermediate lang for bytecode generation.

--- a/content/_posts/2019-11-27-functional-jvm-arrow-fx-meta.md
+++ b/content/_posts/2019-11-27-functional-jvm-arrow-fx-meta.md
@@ -1,10 +1,10 @@
 ---
-title: Functional JVM Meetup - Arrow Fx & Arrow Meta - Functional Programming for the masses
-icon: /img/icon-video.svg
+title: Arrow Fx & Arrow Meta - Functional Programming for the masses
 header-image: https://img.youtube.com/vi/DaognWtZCbs/maxresdefault.jpg
-category: videos
+category: conferences
 tags: [meta, fx]
 link: https://www.youtube.com/watch?v=DaognWtZCbs
+event: Functional JVM Meetup, Prague
 ---
 In this meetup we discuss the new features of Arrow Fx to write “effectful” programs with an emphasis on simple and declarative programming for everyone.
 Additionally, we see how Arrow Meta works and how we can use it to improve the ergonomics of Functional Programming in Kotlin.

--- a/content/media/slidedecks/slidedecks.md
+++ b/content/media/slidedecks/slidedecks.md
@@ -1,0 +1,7 @@
+---
+layout: media_slidedecks
+title: SlideDecks
+category: slidedecks
+permalink: /slidedecks/
+tags: [slides, deck]
+---


### PR DESCRIPTION
### Context

There is just **one** resource as a **conference** and it was previously considered in the **news** category:

```
----
-title: Functional Hangman Game written with Arrow
-icon: /img/icon-news.svg
-version: version 0.8.1
-header-image: /img/blog-image-header.png
-category: news
-link: https://lordraydenmk.github.io/2018/functional-hangman-in-kotlin-with-arrow/
----
-[Functional Hangman](https://lordraydenmk.github.io/2018/functional-hangman-in-kotlin-with-arrow/) game - console application written with Arrow. Uses the `IO<A>` monad to push side effects to the edge of the system.
```

At the same time:

* All the conferences have **videos** category.
* There are resources with `podcast` icon and they don't have that category.
* `icon` and `category` don't match for all the posts.

### Changes

- Fix the category of "Functional Hangman Game written with Arrow" as an **article**.
- Fix the category of all the conferences.
- Add `event` to the last conferences.
- Add **slidedecks** category.
- Remove icon from every resource. It's set from category.

### Screenshot

![Screenshot from 2019-12-22 14-34-55](https://user-images.githubusercontent.com/22792183/71322580-5ddccf80-24c9-11ea-98d5-b015fa19a079.png)


