### PR TITLE
Missed github modal and slack link

### DIFF
--- a/content/_layouts/media_slidedecks.html
+++ b/content/_layouts/media_slidedecks.html
@@ -8,6 +8,8 @@
   {% include _icon-filter.html %}
   {% include _article-list.html blogCategory = "slidedecks"%}
   {% include _books-list.html%}
+  {% include _github-modal.html %}
+  {% include _slack-link.html %}
   {% include _footer.html %}
 </body>
 


### PR DESCRIPTION
This adds github modal and slack link to `SlideDecks` section