### PR TITLE
Hide/show slack channel text box

### DIFF
--- a/content/_includes/_github-modal.html
+++ b/content/_includes/_github-modal.html
@@ -1,6 +1,8 @@
 <div id="star-modal">
-    <p>Do you like Arrow?</p>
-    <span class="close-modal">✖</span>
+    <div class="stars-text-line">
+      <p>Do you like Arrow?</p>
+      <span class="close-modal" title="Close panel">✖</span>
+    </div>
     <a class="github-button" href="https://github.com/arrow-kt/arrow" data-color-scheme="no-preference: light; light: light; dark: light;" data-size="large" data-show-count="true" aria-label="Star arrow-kt/arrow on GitHub">Arrow Org</a>
     <script>
       if (sessionStorage.getItem("dismissed") !== "true") {

--- a/content/_includes/_slack-link.html
+++ b/content/_includes/_slack-link.html
@@ -1,6 +1,22 @@
+<div class="show-slack-icon" title="Show slack panel"><</div>
 <div class="slack-link-container" >
-  <span>Join us at</span>
-  <br>
+  <div class="slack-head-line">
+    <span>Join us at</span>
+    <div class="hide-slack-icon" title="Hide slack panel">
+      >
+    </div>
+  </div>
   <a class="slack-link" href="{{ site.slack_kotlin_channel }}" target="_blank" title="Slack Kotlin channel">slack.kotlinlang.org</a>
   <a class="slack-link" href="{{ site.slack_arrow_channel }}" target="_blank" title="Slack Arrow channel">#arrow</a>
+  <script>
+    document.querySelector(".hide-slack-icon").addEventListener("click", function () {
+      document.querySelector(".slack-link-container").classList.add("slack-text-out");
+      document.querySelector(".show-slack-icon").classList.add("show-slack-icon-visible");
+    });
+
+    document.querySelector(".show-slack-icon").addEventListener("click", function () {
+      document.querySelector(".slack-link-container").classList.remove("slack-text-out");
+      document.querySelector(".show-slack-icon").classList.remove("show-slack-icon-visible");
+    });
+  </script>
 </div>

--- a/content/_sass/base/_helpers.scss
+++ b/content/_sass/base/_helpers.scss
@@ -14,9 +14,9 @@
     transform: scale(0);
     border-radius: 2px;
     position: fixed;
-    bottom: 70px;
+    bottom: 77px;
     right: ($base-point-grid * 2);
-    padding: 12px 11px 8px 12px;
+    padding: $base-point-grid;
     background: $white;
     color: $github-modal-text-color;
     box-shadow: $box-shadow-button;
@@ -36,9 +36,18 @@
     }
     & .close-modal {
         cursor: pointer;
-        position: absolute;
-        top: 12px;
-        right: 6px;
-        padding: 0 $base-point-grid;
+        padding: 1px 10.5px;
+        width: $text-box-icon-size;
+        height: $text-box-icon-size;
+        border-radius: ($base-point-grid * 3);
+
+        &:hover {
+          background-color: lighten($brand-tertiary, 15%);
+        }
+    }
+
+    .stars-text-line {
+      display: flex;
+      justify-content: space-between;
     }
 }

--- a/content/_sass/components/_button.scss
+++ b/content/_sass/components/_button.scss
@@ -58,7 +58,7 @@
   text-transform: uppercase;
   text-align: center;
   text-decoration: none;
-  transition: all .3s ease;
+  transition: right .3s ease;
   box-shadow: $box-shadow-button;
   background: $white;
   font-weight: $font-semibold;
@@ -71,4 +71,51 @@
       color: $github-modal-text-color;
     }
   }
+
+  .slack-head-line {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+}
+
+.hide-slack-icon {
+  font-size: $base-font-size;
+  cursor: pointer;
+  width: $text-box-icon-size;
+  height: $text-box-icon-size;
+  border-radius: ($base-point-grid * 3);
+  margin-right: 2px;
+  padding: 2px;
+
+  &:hover {
+    background-color: lighten($brand-tertiary, 15%);
+  }
+}
+
+.show-slack-icon {
+  color: $github-modal-text-color;
+  font-weight: $font-semibold;
+  font-size: $base-font-size;
+  cursor: pointer;
+  position: fixed;
+  right: -80px;
+  bottom: 30px;
+  background-color: lighten($brand-tertiary, 15%);
+  border-radius: ($base-point-grid * 3) 0 0 ($base-point-grid * 3);
+  transition: padding .2s ease, right .2s ease, left .2s ease;
+  padding: 5px ($base-point-grid * 2);
+  box-shadow: 0 1px 1px 0 rgba($brand-tertiary,.3),0 1px 3px 1px rgba($brand-tertiary,.15);
+
+  &:hover {
+    padding-right: ($base-point-grid * 3);
+  }
+}
+
+.show-slack-icon-visible {
+  right: 0;
+}
+
+.slack-text-out {
+  right: -200px;
 }

--- a/content/_sass/utils/_variables.scss
+++ b/content/_sass/utils/_variables.scss
@@ -46,6 +46,7 @@ $article-font-size: 16px;
 // -----------------------------------------------
 $base-point-grid: 8px;
 $github-modal-width: 178px;
+$text-box-icon-size: 27px;
 // Animation
 // -----------------------------------------------
 $base-duration: 250ms;


### PR DESCRIPTION
This PR adds hide and show button in the slack channel text box.
The same has been done in [Arrow repo](https://github.com/arrow-kt/arrow/pull/1944) and [Arrow Meta](https://github.com/arrow-kt/arrow-meta/pull/426)

This closes #22 