### PR TITLE
Create 2022-06-14-arrow-kotlin-dev-day.md

### DIFF
--- a/content/_posts/2022-06-14-arrow-kotlin-dev-day.md
+++ b/content/_posts/2022-06-14-arrow-kotlin-dev-day.md
@@ -1,0 +1,8 @@
+---
+title: "Arrow put on a big show at Kotlin Dev Day"
+header-image: https://www.47deg.com/assets/img/blog/featured_images/2022-06-13-arrow-put-on-big-show-at-kotlin-dev-day.jpg
+category: articles
+tags: [core, fx]
+link: https://www.47deg.com/blog/arrow-put-on-big-show-at-kotlindevday/
+---
+A recap of the attention Arrow received at Kotlin Dev Day.


### PR DESCRIPTION
Adds the Kotlin Dev Day blog post to Arrow Media.